### PR TITLE
210707_onesignal push to navigate page with new url

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,22 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:nowonbokji/view_page.dart';
+import 'package:nowonbokji/view_page_test.dart';
 import 'package:onesignal_flutter/onesignal_flutter.dart';
 
+
+final GlobalKey<NavigatorState> navigatorKey = new GlobalKey<NavigatorState>();
 
 void main() {
   runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: '시립노원노인복지관',
-      theme: ThemeData(
-
-        primarySwatch: Colors.amber,
-      ),
+      theme: ThemeData(primarySwatch: Colors.amber),
       home: MyHomePage(),
     );
   }
@@ -31,7 +30,6 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   static final String oneSignalAppId ="e579a66a-9ba5-44ed-b317-13dc1609da4a";
-  String _debugLabelString = "";
   bool _requireConsent = false;
 
   @override
@@ -43,32 +41,23 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: ViewPage(
-
-      ),
+      home: ViewPage(),
+      navigatorKey: navigatorKey,
     );
   }
 
   Future<void> initPlatformState() async {
     OneSignal.shared.setAppId(oneSignalAppId);
-    if (!mounted) return;
-
     OneSignal.shared.setLogLevel(OSLogLevel.verbose, OSLogLevel.none);
-
     OneSignal.shared.setRequiresUserPrivacyConsent(_requireConsent);
-
-    OneSignal.shared
-        .setNotificationOpenedHandler((OSNotificationOpenedResult result) {
+    OneSignal.shared.setNotificationOpenedHandler((OSNotificationOpenedResult result) {
       print("OPENED NOTIFICATION");
       print(result.notification.jsonRepresentation().replaceAll("\\n", "\n"));
-      this.setState(() {
-        _debugLabelString =
-        "Opened notification: \n${result.notification.jsonRepresentation().replaceAll("\\n", "\n")}";
-      });
-    });
+      String url = result.notification.additionalData['u'];
+      navigatorKey.currentState.pushAndRemoveUntil(MaterialPageRoute(builder: (context) => ViewPageTest(getURL: url,)), (Route<dynamic> route) => false);
 
-    OneSignal.shared
-        .setSubscriptionObserver((OSSubscriptionStateChanges changes) {
+    });
+    OneSignal.shared.setSubscriptionObserver((OSSubscriptionStateChanges changes) {
       print("SUBSCRIPTION STATE CHANGED: ${changes.jsonRepresentation()}");
     });
 
@@ -76,14 +65,10 @@ class _MyHomePageState extends State<MyHomePage> {
       print("PERMISSION STATE CHANGED: ${changes.jsonRepresentation()}");
     });
 
-    OneSignal.shared.setEmailSubscriptionObserver(
-            (OSEmailSubscriptionStateChanges changes) {
-          print("EMAIL SUBSCRIPTION STATE CHANGED ${changes.jsonRepresentation()}");
-        });
-
-
+    OneSignal.shared.setEmailSubscriptionObserver((OSEmailSubscriptionStateChanges changes) {
+        print("EMAIL SUBSCRIPTION STATE CHANGED ${changes.jsonRepresentation()}");
+      });
 
     OneSignal.shared.promptUserForPushNotificationPermission(fallbackToSettings: true);
-
   }
 }

--- a/lib/view_page_test.dart
+++ b/lib/view_page_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:nowonbokji/browser.dart';
+
+class ViewPageTest extends StatefulWidget {
+  final String getURL;
+
+  ViewPageTest({Key key, this.getURL}) : super(key: key);
+
+  final ChromeSafariBrowser browser = new MyChromeSafariBrowser(new MyInAppBrowser());
+
+  @override
+  _ViewPageState createState() => _ViewPageState();
+}
+
+
+class _ViewPageState extends State<ViewPageTest> {
+  InAppWebViewController webView;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Future<bool> _exitApp(BuildContext context) async {
+    if (await webView.canGoBack()) {
+      webView.goBack();
+    } else {
+      return showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text("앱을 종료 하시겠습니까?"),
+          actions: <Widget>[
+            FlatButton(
+              child: Text("아니요"),
+              onPressed: () => Navigator.pop(context, false),
+            ),
+            FlatButton(
+              child: Text("네"),
+              onPressed: () => Navigator.pop(context, true),
+            ),
+          ],
+        ),
+      ) ??
+          false;
+    }
+  }
+
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () => _exitApp(context),
+      child: Scaffold(
+        resizeToAvoidBottomInset: false,
+        body: Builder(builder: (BuildContext context) {
+          return SafeArea(
+            child: InAppWebView(
+              initialUrl: widget.getURL,
+              initialHeaders: {},
+              initialOptions: InAppWebViewGroupOptions(
+                crossPlatform: InAppWebViewOptions(
+                  debuggingEnabled: true,
+                  useShouldOverrideUrlLoading: true,
+                  javaScriptCanOpenWindowsAutomatically: false,
+                ),
+              ),
+              onWebViewCreated: (InAppWebViewController controller) async {
+                webView = controller;
+              },
+
+            ),
+          );
+        }
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
main파일에 global navigateKey를 추가했습니다.
Onesingal open handler에서 navigatorKey를 이용해서 받은 url을 가지고 웹뷰 페이지로 이동합니다.
웹뷰페이지는 받은 url을 보여줍니다.